### PR TITLE
Define una primera unitaria y un primer método de ejecución

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .nrepl-port
 .cpcache/
 /.idea
+*~

--- a/README.md
+++ b/README.md
@@ -6,5 +6,10 @@ Es una aplicación web extensible mediante plugins. Similar a Wordpress, pero si
 # Plugins
 Nuevas funciones pueden ser añadidas en caliente mediante plugins en forma de archivos .jar
 
+# Probar
 
+Realiza todas las pruebas incluídas con el siguiente comando:
 
+```
+clojure -M:test
+```

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        expectations/clojure-test {:mvn/version "1.2.1"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                 :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}}
+         :main-opts ["-m" "cognitect.test-runner"
+                     "-d" "test"]}}}

--- a/test/matrix/matrix_test.clj
+++ b/test/matrix/matrix_test.clj
@@ -1,0 +1,6 @@
+(ns matrix.matrix-test
+  (:require [clojure.test :refer [deftest is]]
+            [expectations.clojure.test :refer [defexpect expect]]))
+
+(deftest smoke-test-1 (is (= 1 1)))
+(defexpect smoke-test-2 (expect 1 1))


### PR DESCRIPTION
Consideramos utilizar [expectations/clojure-test](https://github.com/clojure-expectations/clojure-test) para describir las pruebas unitarias.

Inspirado en la forma en que ese mismo proyecto define sus pruebas, propuse esta solución para las pruebas unitarias basada en el «runnre» [com.cognitect/test-runner](https://github.com/cognitect-labs/test-runner).

Toda la documentación de ambos proyectos se enfocan en el uso de deps.edn, por lo que seguí esa guía para esta primera entrega. No quiere decir esto que debamos casarnos con deps.edn y haya descartado Lein o Boot.

